### PR TITLE
Avoid torch.bool overflow in accuracy and IoU calculations.

### DIFF
--- a/experiments/exp3_2d3ds/test.py
+++ b/experiments/exp3_2d3ds/test.py
@@ -68,8 +68,8 @@ def iou_score(pred_cls, true_cls, nclass=15, drop=drop):
     union_ = []
     for i in range(nclass):
         if i not in drop:
-            intersect = ((pred_cls == i) + (true_cls == i)).eq(2).sum().item()
-            union = ((pred_cls == i) + (true_cls == i)).ge(1).sum().item()
+            intersect = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).sum().item()
+            union = ((pred_cls == i).int() + (true_cls == i).int()).ge(1).sum().item()
             intersect_.append(intersect)
             union_.append(union)
     return np.array(intersect_), np.array(union_)

--- a/experiments/exp3_2d3ds/train.py
+++ b/experiments/exp3_2d3ds/train.py
@@ -56,8 +56,8 @@ def iou_score(pred_cls, true_cls, nclass=15, drop=drop):
     union_ = []
     for i in range(nclass):
         if i not in drop:
-            intersect = ((pred_cls == i) + (true_cls == i)).eq(2).sum().item()
-            union = ((pred_cls == i) + (true_cls == i)).ge(1).sum().item()
+            intersect = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).sum().item()
+            union = ((pred_cls == i).int() + (true_cls == i).int()).ge(1).sum().item()
             intersect_.append(intersect)
             union_.append(union)
     return np.array(intersect_), np.array(union_)
@@ -68,7 +68,7 @@ def accuracy(pred_cls, true_cls, nclass=15, drop=drop):
     tpos = []
     for i in range(nclass):
         if i not in drop:
-            true_positive = ((pred_cls == i) + (true_cls == i)).eq(2).sum().item()
+            true_positive = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).sum().item()
             tpos.append(true_positive)
             per_cls_counts.append(positive[i])
     return np.array(tpos), np.array(per_cls_counts)

--- a/experiments/exp4_sphere_climate/test.py
+++ b/experiments/exp4_sphere_climate/test.py
@@ -66,10 +66,10 @@ def iou_score(pred_cls, true_cls, nclass=3):
     """
     iou = []
     for i in range(nclass):
-        # intersect = ((pred_cls == i) + (true_cls == i)).eq(2).item()
-        # union = ((pred_cls == i) + (true_cls == i)).ge(1).item()
-        intersect = ((pred_cls == i) + (true_cls == i)).eq(2).sum().item()
-        union = ((pred_cls == i) + (true_cls == i)).ge(1).sum().item()
+        # intersect = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).item()
+        # union = ((pred_cls == i).int() + (true_cls == i).int()).ge(1).item()
+        intersect = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).sum().item()
+        union = ((pred_cls == i).int() + (true_cls == i).int()).ge(1).sum().item()
         # print("Intersect: ", intersect, " Union: ", union)
         iou_ = intersect / union
         iou.append(iou_)
@@ -81,8 +81,8 @@ def accuracy(pred_cls, true_cls, nclass=3):
     """
     accu = []
     for i in range(nclass):
-        intersect = ((pred_cls == i) + (true_cls == i)).eq(2).sum().item()
-        thiscls = (true_cls == i).sum().item()
+        intersect = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).sum().item()
+        thiscls = (true_cls == i).int().sum().item()
         accu.append(intersect / thiscls)
     return np.array(accu)
 

--- a/experiments/exp4_sphere_climate/train.py
+++ b/experiments/exp4_sphere_climate/train.py
@@ -38,10 +38,10 @@ def iou_score(pred_cls, true_cls, nclass=3):
     """
     iou = []
     for i in range(nclass):
-        # intersect = ((pred_cls == i) + (true_cls == i)).eq(2).item()
-        # union = ((pred_cls == i) + (true_cls == i)).ge(1).item()
-        intersect = ((pred_cls == i) + (true_cls == i)).eq(2).sum().item()
-        union = ((pred_cls == i) + (true_cls == i)).ge(1).sum().item()
+        # intersect = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).item()
+        # union = ((pred_cls == i).int() + (true_cls == i).int()).ge(1).item()
+        intersect = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).sum().item()
+        union = ((pred_cls == i).int() + (true_cls == i).int()).ge(1).sum().item()
         iou_ = intersect / union
         iou.append(iou_)
     return np.array(iou)
@@ -58,8 +58,8 @@ def accuracy(pred_cls, true_cls, nclass=3):
     """
     accu = []
     for i in range(nclass):
-        intersect = ((pred_cls == i) + (true_cls == i)).eq(2).sum().item()
-        thiscls = (true_cls == i).sum().item()
+        intersect = ((pred_cls == i).int() + (true_cls == i).int()).eq(2).sum().item()
+        thiscls = (true_cls == i).int().sum().item()
         accu.append(intersect / thiscls)
     return np.array(accu)
 


### PR DESCRIPTION
 Before pytorch 1.1, torch.uint8 was used for binary operations, but this is no longer the case.